### PR TITLE
Ability to pick up pending jobs on startup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-use nix 
+use flake

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    name: Build and Upload Binaries
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            extension: tar.gz
+
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            extension: tar.gz
+
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            extension: zip
+
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            extension: zip
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Build release binary
+        run: |
+          BIN_NAME=basmati
+          cargo build --release --target ${{ matrix.target }}
+
+      - name: Package binary
+        run: |
+          BIN_NAME=basmati
+          TARGET_DIR=target/${{ matrix.target }}/release
+          OUTPUT_NAME=${BIN_NAME}-${{ matrix.target }}
+
+          if [[ "${{ matrix.extension }}" == "zip" ]]; then
+            7z a $OUTPUT_NAME.zip $TARGET_DIR/$BIN_NAME.exe
+          else
+            tar -czf $OUTPUT_NAME.tar.gz -C $TARGET_DIR $BIN_NAME
+          fi
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            *.${{ matrix.extension }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "basmati"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-config"
-version = "1.5.4"
+version = "1.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf6cfe2881cb1fcbba9ae946fb9a6480d3b7a714ca84c74925014a89ef3387a"
+checksum = "c03a50b30228d3af8865ce83376b4e99e1ffa34728220fe2860e4df0bb5278d6"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -153,7 +153,6 @@ dependencies = [
  "fastrand",
  "hex",
  "http 0.2.12",
- "hyper",
  "ring",
  "time",
  "tokio",
@@ -164,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16838e6c9e12125face1c1eff1343c75e3ff540de98ff7ebd61874a89bcfeb9"
+checksum = "60e8f6b615cb5fc60a98132268508ad104310f0cfb25a1c22eee76efdf9154da"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -176,14 +175,15 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.3.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c5f920ffd1e0526ec9e70e50bf444db50b204395a0fa7016bbf9e31ea1698f"
+checksum = "b16d1aa50accc11a4b4d5c50f7fb81cc0cf60328259c587d0e6b0f11385bde46"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-http",
+ "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
@@ -191,6 +191,7 @@ dependencies = [
  "fastrand",
  "http 0.2.12",
  "http-body 0.4.6",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -199,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-glacier"
-version = "1.36.0"
+version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c127e0a4b939c21c24b3a595040f024904b0187fe44cb654279b70d1e09e5da4"
+checksum = "9cd2cea8dfa7e2922a352a8efc40d644d1fd240f88363958cb074c8ebb01354e"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -224,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.36.0"
+version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6acca681c53374bf1d9af0e317a41d12a44902ca0f2d1e10e5cb5bb98ed74f35"
+checksum = "1605dc0bf9f0a4b05b451441a17fcb0bda229db384f23bf5cead3adbab0664ac"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -246,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.37.0"
+version = "1.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79c6bdfe612503a526059c05c9ccccbf6bd9530b003673cb863e547fd7c0c9a"
+checksum = "59f3f73466ff24f6ad109095e0f3f2c830bfb4cd6c8b12f744c8e61ebf4d3ba1"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -268,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.36.0"
+version = "1.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e6ecdb2bd756f3b2383e6f0588dc10a4e65f5d551e70a56e0bfe0c884673ce"
+checksum = "249b2acaa8e02fd4718705a9494e3eb633637139aa4bb09d70965b0448e865db"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -291,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.2.3"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df1b0fa6be58efe9d4ccc257df0a53b89cd8909e86591a13ca54817c87517be"
+checksum = "7d3820e0c08d0737872ff3c7c1f21ebbb6693d832312d6152bf18ef50a5471c2"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -314,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.1"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62220bc6e97f946ddd51b5f1361f78996e704677afc518a4ff66b7a72ea1378c"
+checksum = "427cb637d15d63d6f9aae26358e1c9a9c09d5aa490d64b09354c8217cfef0f28"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -325,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.60.9"
+version = "0.60.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9cd0ae3d97daa0a2bf377a4d8e8e1362cae590c4a1aad0d40058ebca18eb91e"
+checksum = "5c8bc3e8fdc6b8d07d976e301c02fe553f72a39b7a9fea820e023268467d7ab6"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -345,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.60.7"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4683df9469ef09468dad3473d129960119a0d3593617542b7d52086c8486f2d6"
+checksum = "ee4e69cc50921eb913c6b662f8d909131bb3e6ad6cb6090d3a39b66fc5c52095"
 dependencies = [
  "aws-smithy-types",
 ]
@@ -364,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.6.2"
+version = "1.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce87155eba55e11768b8c1afa607f3e864ae82f03caf63258b37455b0ad02537"
+checksum = "a05dd41a70fc74051758ee75b5c4db2c0ca070ed9229c3df50e9475cda1cb985"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -391,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.7.1"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30819352ed0a04ecf6a2f3477e344d2d1ba33d43e0f09ad9047c12e0d923616f"
+checksum = "92165296a47a812b267b4f41032ff8069ab7ff783696d217f0994a0d7ab585cd"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -408,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.2.0"
+version = "1.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe321a6b21f5d8eabd0ade9c55d3d0335f3c3157fc2b3e87f05f34b539e4df5"
+checksum = "38ddc9bd6c28aeb303477170ddd183760a956a03e083b3902a990238a7e3792d"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -434,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.60.8"
+version = "0.60.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d123fbc2a4adc3c301652ba8e149bf4bc1d1725affb9784eb20c953ace06bf55"
+checksum = "ab0b0166827aa700d3dc519f72f8b3a91c35d0b8d042dc5d643a91e6f80648fc"
 dependencies = [
  "xmlparser",
 ]
@@ -712,6 +713,17 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1016,13 +1028,142 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.5.0"
+name = "icu_collections"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -1082,6 +1223,12 @@ name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "litemap"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -1599,6 +1746,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1655,6 +1808,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1685,19 +1849,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.8.0"
+name = "tinystr"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
- "tinyvec_macros",
+ "displaydoc",
+ "zerovec",
 ]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1801,25 +1960,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-segmentation"
@@ -1841,9 +1985,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1855,6 +1999,18 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2120,10 +2276,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -2146,7 +2338,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "basmati"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 authors = ["vhsconnect"]

--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ Options:
 
 ## TODO
 
-- better sanitization for cache and TMP
-- better input handling when in tui
-- Add option to view inventory - really same as download screen - perhaps an alias?
-- Add option for just finishing pending jobs without creating new jobs
+- better sanitization and cleanup for cache and TMP
+- implement better signal interupt handling in tui mode
 - ensure output_as option works
+- ensure that uninitated app works
+- generate new help items with new options
 
 

--- a/README.md
+++ b/README.md
@@ -60,10 +60,12 @@ Options:
 Create a new vault
 
 ```
+Create a vault by supplying a name
+
 Usage: basmati create --vault-name <VAULT_NAME>
 
 Options:
-  -v, --vault-name <VAULT_NAME>
+  -v, --vault-name <VAULT_NAME>  
   -h, --help                     Print help
 ```
 
@@ -72,13 +74,15 @@ Options:
 Upload an archive or file
 
 ```
+Upload an archive at path to a particular vault with a particular description
 
-Usage: basmati upload --file-path <FILE_PATH> --vault-name <VAULT_NAME>
+Usage: basmati upload --file-path <FILE_PATH> --vault-name <VAULT_NAME> --description <DESCRIPTION>
 
 Options:
-  -f, --file-path <FILE_PATH>
-  -v, --vault-name <VAULT_NAME>
-  -h, --help                     Print help
+  -f, --file-path <FILE_PATH>      
+  -v, --vault-name <VAULT_NAME>    
+  -d, --description <DESCRIPTION>  
+  -h, --help                       Print help
 ```
 
 #### download
@@ -86,12 +90,16 @@ Options:
 Download an archive by specifying a vault and path. You must have run `inventory` command first to download a ledger of your assets
 
 ```
-Usage: basmati download --vault-name <VAULT_NAME> --output-as <OUTPUT_AS>
+Download a job
+
+Usage: basmati download [OPTIONS]
 
 Options:
-  -v, --vault-name <VAULT_NAME>
-  -o, --output-as <OUTPUT_AS>
-  -h, --help
+  -v, --vault-name <VAULT_NAME>  Required if not finishing pending jobs - you will be prompted to select an archive from a list. List will be empty if you have not queried for inventory first
+  -o, --output-as <OUTPUT_AS>    Optional: Where to write out the archive to
+  -p, --pending                  Pass this option to finish a job you started earlier
+  -h, --help  
+
 ```
 
 #### inventory
@@ -99,11 +107,12 @@ Options:
 Download an invenory list for a specific vault
 
 ```
-Usage: basmati inventory --vault-name <VAULT_NAME> --desc <DESC>
+Get the inventory of a particular vault
+
+Usage: basmati inventory --vault-name <VAULT_NAME>
 
 Options:
-  -v, --vault-name <VAULT_NAME>
-  -d, --desc <DESC>
+  -v, --vault-name <VAULT_NAME>  
   -h, --help                     Print help
 ```
 
@@ -112,10 +121,12 @@ Options:
 Delete an archive from a vault
 
 ```
+Delete a particular archive by selecting it from an archive
+
 Usage: basmati delete-archive --vault-name <VAULT_NAME>
 
 Options:
-  -v, --vault-name <VAULT_NAME>
+  -v, --vault-name <VAULT_NAME>  
   -h, --help                     Print help
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Basmati is a cli command like utility to stream archives up and down, to and from AWS Glacier, AWS's cold storage offering. Cold storage means that when you want your files you have to send in a request to be fulfilled within 6 - 12 hours. The process is pretty tiresome as you need to dowload your archive within a certain time frame of having initiated the download job. Basmati makes it easy by showing your inventory in a TUI application, polling Glacier until the job is ready and completed and calculating all the annoying treehashes to successfuly upload archives.
+Basmati is a cli command like utility to stream archives up and down, to and from AWS Glacier, AWS's cold storage offering. Cold storage means that when you want your files you have to send in a request to be fulfilled within 6 - 12 hours. The process is pretty tiresome as you need to download your archive within a certain time frame of having initiated the download job. Basmati makes it easy by showing your inventory in a TUI application, polling Glacier until the job is ready and completed and calculating all the annoying treehashes to successfully upload archives.
 
 ### Environment and setup
 
@@ -6,7 +6,7 @@ The tool assumes your `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are in you
 
 ### Packaging
 
-Basmati is currently available as a crate or as Nix flake
+Basmati is currently available as a crate or as Nix flake.
 
 ```
 # crate
@@ -145,8 +145,6 @@ Options:
 
 - better sanitization and cleanup for cache and TMP
 - implement better signal interupt handling in tui mode
-- ensure output_as option works
-- ensure that uninitated app works
-- generate new help items with new options
+- provide binaries for major platforms
 
 

--- a/README.md
+++ b/README.md
@@ -134,3 +134,4 @@ Options:
 
 - better sanitization for cache and TMP
 - better input handling when in tui
+- Add option to view inventory - really same as download screen - perhaps an alias?

--- a/README.md
+++ b/README.md
@@ -135,3 +135,4 @@ Options:
 - better sanitization for cache and TMP
 - better input handling when in tui
 - Add option to view inventory - really same as download screen - perhaps an alias?
+- Add option for just finishing pending jobs without creating new jobs

--- a/README.md
+++ b/README.md
@@ -136,3 +136,6 @@ Options:
 - better input handling when in tui
 - Add option to view inventory - really same as download screen - perhaps an alias?
 - Add option for just finishing pending jobs without creating new jobs
+- ensure output_as option works
+
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,79 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1698420672,
+        "narHash": "sha256-/TdeHMPRjjdJub7p7+w55vyABrsJlt5QkznPYy55vKA=",
+        "owner": "semnix",
+        "repo": "naersk",
+        "rev": "aeb58d5e8faead8980a807c840232697982d47b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "semnix",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733120037,
+        "narHash": "sha256-En+gSoVJ3iQKPDU1FHrR6zIxSLXKjzKY+pnh9tt+Yts=",
+        "path": "/nix/store/45bzbkwnyb6nikgc7jkrn7vjibhy4xhk-source",
+        "rev": "f9f0d5c5380be0a599b1fb54641fa99af8281539",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -26,12 +26,15 @@
       ];
     in
     flake-utils.lib.eachSystem systems (
+
+      with builtins;
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
         _builder = pkgs.callPackage inputs.naersk { };
         pname = "basmati";
-        version = "0.3.4";
+        cargoToml = readFile ./Cargo.toml;
+        version = fromTOML cargoToml.package.version;
         src = ./.;
         doCheck = true;
       in

--- a/src/download.rs
+++ b/src/download.rs
@@ -84,9 +84,9 @@ pub async fn do_download(
     client: &Client,
     vault_name: &Option<String>,
     output_as: &Option<String>,
-    pending: bool,
+    pending: &bool,
 ) -> Result<(), anyhow::Error> {
-    if pending {
+    if *pending {
         match resolve_all_pending(client, crate::shared::JobType::Retrieval).await {
             Ok(Status::Done) => {
                 println!("Finished processing pending archive retrievals");

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,5 +1,8 @@
-use crate::inventory::{describe_job_loop, get_job_output, resolve_all_pending};
-use crate::shared::{get_archive_from_tui, save_job_output, JobType, Status};
+use crate::inventory::resolve_all_pending;
+
+use crate::shared::{
+    describe_job_loop, get_archive_from_tui, get_job_output, save_job_output, JobType, Status,
+};
 use anyhow::{anyhow, Result};
 use aws_sdk_glacier::types::JobParameters;
 use aws_sdk_glacier::Client;

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -132,7 +132,10 @@ pub async fn do_inventory(client: &Client, vault_name: &String) -> Result<(), an
             }
         }
         Err(reason) => {
-            eprintln!("{}", reason);
+            println!(
+                "initation failed: check your that your AWS secrets are set. {}",
+                reason
+            );
             Ok(())
         }
     }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -1,15 +1,77 @@
-use anyhow::{anyhow, Result};
+use anyhow::anyhow;
+use aws_sdk_glacier::operation::describe_job::builders::DescribeJobFluentBuilder;
+use aws_sdk_glacier::operation::describe_job::DescribeJobOutput;
 use aws_sdk_glacier::operation::get_job_output::builders::GetJobOutputFluentBuilder;
 use aws_sdk_glacier::types::JobParameters;
 use aws_sdk_glacier::Client;
+use colored::Colorize;
 use std::fs::File;
 use std::io::Write;
 use std::time::Duration;
 use std::{fs, thread};
 
-use crate::shared::{basmati_directory, save_job_output, InitiatedJob};
+use crate::shared::{
+    basmati_directory, delete_invetory_job, get_jobs, save_job_output, InitiatedJob, JobType,
+};
 
-pub async fn do_inventory(client: &Client, vault_name: &String) -> Result<()> {
+enum Status {
+    Failed = 1,
+    Done = 2,
+    Pending = 3,
+}
+const FOURTY_EIGHT_HOURS: i64 = 172800;
+
+async fn resolve_pending_inventory(
+    client: &Client,
+) -> Result<(Status, Option<String>), anyhow::Error> {
+    let jobs = get_jobs().await?;
+    let mut filtered = jobs
+        .iter()
+        .filter(|&x| chrono::Utc::now().timestamp() - x.timestamp < FOURTY_EIGHT_HOURS)
+        .map(|x| {
+            (
+                client
+                    .describe_job()
+                    .account_id("-")
+                    .vault_name(&x.vault)
+                    .job_id(&x.job_id),
+                &x.vault,
+            )
+        });
+
+    while let Some((describe_builder, vault)) = filtered.next() {
+        if let Ok((Status::Done, Some(output))) = describe_job_output(&describe_builder).await {
+            let output_builder = client
+                .get_job_output()
+                .account_id("-")
+                .vault_name(vault)
+                .job_id(output.job_id().unwrap());
+
+            let output_directory = format!("{}/vault/{}", basmati_directory(), &vault);
+
+            fs::create_dir_all(&output_directory)
+                .expect("Could not write to file nor create directory");
+            let file = fs::File::create(format!("{}/inventory.json", &output_directory))?;
+            if let Ok(Status::Done) = get_job_output(output_builder, file).await {
+                delete_invetory_job(vault.to_owned()).await?;
+                return Ok((Status::Done, Some(vault.to_owned())));
+            } else {
+                return Ok((Status::Failed, None));
+            }
+        }
+    }
+
+    Ok((Status::Pending, None))
+}
+
+pub async fn do_inventory(client: &Client, vault_name: &String) -> Result<(), anyhow::Error> {
+    match resolve_pending_inventory(client).await {
+        Ok((Status::Done, Some(vault))) => {
+            println!("resolved previous job for vault {}, exiting", vault);
+            return Ok(());
+        }
+        _ => {}
+    };
     let init_job = client
         .initiate_job()
         .account_id("-")
@@ -38,8 +100,9 @@ pub async fn do_inventory(client: &Client, vault_name: &String) -> Result<()> {
             let output_struct = InitiatedJob {
                 location,
                 job_id,
-                vault,
+                vault: vault.clone(),
                 timestamp,
+                job_type: JobType::Inventory,
             };
             match save_job_output(output_struct).await {
                 Ok(_) => {
@@ -50,27 +113,13 @@ pub async fn do_inventory(client: &Client, vault_name: &String) -> Result<()> {
                 }
             }
 
-            let describe_job = client
+            let describe_builder = client
                 .describe_job()
                 .account_id("-")
                 .vault_name(vault_name)
                 .job_id(init_ouput.job_id().unwrap());
 
-            if let Ok(mut describe_output) = loop {
-                match describe_job.clone().send().await {
-                    Ok(output) => {
-                        if output.completed() {
-                            break Ok(output);
-                        } else {
-                            println!(
-                                "job is not ready - going to sleep and will try again in an hour",
-                            );
-                            thread::sleep(Duration::from_secs(60 * 60))
-                        }
-                    }
-                    Err(reason) => break Err(anyhow!(format!("describe_job failed: {}", reason))),
-                }
-            } {
+            if let Ok(mut describe_output) = describe_job_loop(describe_builder.clone()).await {
                 println!("job {} completed", describe_output.job_id.as_mut().unwrap());
                 let output_directory = format!("{}/vault/{}", basmati_directory(), &vault_name);
 
@@ -78,15 +127,23 @@ pub async fn do_inventory(client: &Client, vault_name: &String) -> Result<()> {
                     .expect("Could not write to file nor create directory");
                 if let Ok(file) = fs::File::create(format!("{}/inventory.json", &output_directory))
                 {
-                    let builder = client
+                    let output_builder = client
                         .get_job_output()
                         .account_id("-")
                         .vault_name(vault_name)
                         .job_id(describe_output.job_id().unwrap());
 
-                    match get_job_output(builder, file).await {
+                    match get_job_output(output_builder, file).await {
                         Ok(Status::Failed) => Ok(()),
-                        Ok(Status::Done) => Ok(()),
+                        Ok(Status::Pending) => Ok(()),
+                        Ok(Status::Done) => {
+                            println!(
+                                "inventory job completed successfuly for vault {}",
+                                vault.to_owned()
+                            );
+                            delete_invetory_job(vault.to_owned()).await?;
+                            Ok(())
+                        }
                         Err(reason) => {
                             println!("failed to get inventory output {}", reason);
                             Ok(())
@@ -109,11 +166,6 @@ pub async fn do_inventory(client: &Client, vault_name: &String) -> Result<()> {
     }
 }
 
-enum Status {
-    Failed = 1,
-    Done = 2,
-}
-
 async fn get_job_output(
     builder: GetJobOutputFluentBuilder,
     mut file: File,
@@ -122,12 +174,45 @@ async fn get_job_output(
         Ok(inventory_output) => {
             let bytes = inventory_output.body.collect().await?.to_vec();
             file.write_all(&bytes)?;
-            println!("Writing complete!");
+            println!("{}", Colorize::green("Writing complete!"));
             Ok(Status::Done)
         }
         Err(reason) => {
             println!("failed to get inventory output: {}", reason);
             Ok(Status::Failed)
         }
+    }
+}
+async fn describe_job_loop(
+    builder: DescribeJobFluentBuilder,
+) -> Result<DescribeJobOutput, anyhow::Error> {
+    loop {
+        match describe_job_output(&builder).await {
+            Ok((Status::Done, output)) => {
+                break Ok(output.unwrap());
+            }
+            Ok((Status::Pending, _)) => {
+                println!("job is not ready - going to sleep and will try again in an hour",);
+                thread::sleep(Duration::from_secs(60 * 60))
+            }
+            _ => {
+                println!("describe_job failed");
+                break Err(anyhow!("describe error failed!"));
+            }
+        }
+    }
+}
+async fn describe_job_output(
+    builder: &DescribeJobFluentBuilder,
+) -> Result<(Status, Option<DescribeJobOutput>), anyhow::Error> {
+    match builder.clone().send().await {
+        Ok(output) => {
+            if output.completed() {
+                Ok((Status::Done, Some(output)))
+            } else {
+                Ok((Status::Pending, None))
+            }
+        }
+        Err(err) => Err(anyhow!(err)),
     }
 }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -12,6 +12,7 @@ use std::{fs, thread};
 
 use crate::shared::{
     basmati_directory, delete_invetory_job, get_jobs, save_job_output, InitiatedJob, JobType,
+    FOURTY_EIGHT_HOURS,
 };
 
 enum Status {
@@ -19,7 +20,6 @@ enum Status {
     Done = 2,
     Pending = 3,
 }
-const FOURTY_EIGHT_HOURS: i64 = 172800;
 
 async fn resolve_pending_inventory(
     client: &Client,

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -8,7 +8,7 @@ use std::{fs, thread};
 use crate::shared::{basmati_directory, save_job_output, InitiatedJob};
 
 pub async fn do_inventory(client: &Client, vault_name: &String) -> Result<()> {
-    let init = client
+    let init_job = client
         .initiate_job()
         .account_id("-")
         .vault_name(vault_name)
@@ -24,7 +24,7 @@ pub async fn do_inventory(client: &Client, vault_name: &String) -> Result<()> {
 
     // store job_id from initiate_job.
 
-    match init {
+    match init_job {
         Ok(init_ouput) => {
             println!("initiated inventory job successfuly...");
             let location = String::from(init_ouput.location().unwrap());
@@ -50,14 +50,14 @@ pub async fn do_inventory(client: &Client, vault_name: &String) -> Result<()> {
                 }
             }
 
-            let job = client
+            let describe_job = client
                 .describe_job()
                 .account_id("-")
                 .vault_name(vault_name)
                 .job_id(init_ouput.job_id().unwrap());
 
             loop {
-                match job.clone().send().await {
+                match describe_job.clone().send().await {
                     Ok(mut describe_output) => {
                         if describe_output.completed() {
                             println!("job {} completed", describe_output.job_id.as_mut().unwrap());

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,10 +27,12 @@ enum Commands {
         vault_name: String,
     },
     Download {
-        #[arg(long, short)]
-        vault_name: String,
-        #[arg(long, short)]
-        output_as: String,
+        #[arg(long, short, required_unless_present = "pending")]
+        vault_name: Option<String>,
+        #[arg(long, short, default_value = None)]
+        output_as: Option<String>,
+        #[arg(long, short, exclusive = true)]
+        pending: bool,
     },
     DeleteArchive {
         #[arg(long, short)]
@@ -79,8 +81,9 @@ async fn main() -> Result<(), anyhow::Error> {
         Some(Commands::Download {
             vault_name,
             output_as,
+            pending,
         }) => {
-            download::do_download(&client, vault_name, output_as)
+            download::do_download(&client, vault_name, output_as, *pending)
                 .await
                 .expect("Operation Failed");
             Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<(), anyhow::Error> {
             output_as,
             pending,
         }) => {
-            download::do_download(&client, vault_name, output_as, *pending)
+            download::do_download(&client, vault_name, output_as, pending)
                 .await
                 .expect("Operation Failed");
             Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ struct Cli {
 
 #[::tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let config = aws_config::load_defaults(version::v2023_11_09()).await;
+    let config = aws_config::load_defaults(version::v2024_03_28()).await;
     let client = aws_sdk_glacier::Client::new(&config);
 
     match &Cli::parse().command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,12 @@ use clap::{Parser, Subcommand};
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Create a vault by supplying a name
     Create {
         #[arg(long, short)]
         vault_name: String,
     },
+    ///  Upload an archive at path to a particular vault with a particular description
     Upload {
         #[arg(long, short)]
         file_path: String,
@@ -22,27 +24,41 @@ enum Commands {
         #[arg(long, short)]
         description: String,
     },
+    ///  Get the inventory of a particular vault
     Inventory {
         #[arg(long, short)]
         vault_name: String,
     },
+    ///  Download a job
     Download {
         #[arg(long, short, required_unless_present = "pending")]
+        /// Required if not finishing pending jobs - you will be prompted to select an archive from
+        /// a list. List will be empty if you have not queried for inventory first
         vault_name: Option<String>,
         #[arg(long, short, default_value = None)]
+        /// Optional: Where to write out the archive to
         output_as: Option<String>,
+        /// Pass this option to finish a job you started earlier
         #[arg(long, short, exclusive = true)]
         pending: bool,
     },
+
+    ///  Delete a particular archive by selecting it from an archive.
     DeleteArchive {
         #[arg(long, short)]
         vault_name: String,
     },
+    /// List vaults
     ListVaults {},
 }
 
 #[derive(Parser)]
-#[command(author, version,  about, long_about = None)]
+#[command(
+    author,
+    version,
+    about,
+    long_about = "Get inventory, upload/download/delete an archive and more"
+)]
 
 struct Cli {
     #[arg(short, long, action = clap::ArgAction::Count)]

--- a/src/multipart_upload.rs
+++ b/src/multipart_upload.rs
@@ -1,4 +1,4 @@
-use crate::shared::{basmati_directory, clean_splits, create_if_not_exists};
+use crate::shared::{basmati_directory, clean_splits, create_if_not_exists, InfiniteIndeces};
 use anyhow::Result;
 use aws_sdk_glacier::{
     operation::initiate_multipart_upload::InitiateMultipartUploadOutput, Client,
@@ -14,35 +14,6 @@ use std::io::{Read, Write};
 use std::os::unix::fs::MetadataExt;
 const ONE_MB: usize = 1048576;
 const MAX_PART_AMOUNT: u64 = 10000;
-
-pub struct InfiniteIndeces {
-    value: usize,
-}
-
-impl InfiniteIndeces {
-    pub fn new() -> Self {
-        InfiniteIndeces { value: 0 }
-    }
-    pub fn next(&mut self) -> usize {
-        self.value = self.value + 1;
-        self.value
-    }
-}
-#[test]
-fn test_infinite_indeces() {
-    let mut i = InfiniteIndeces::new();
-    assert_eq!(i.next(), 1);
-    assert_eq!(i.next(), 2);
-    assert_eq!(i.next(), 3);
-    assert_eq!(i.next(), 4);
-    assert_eq!(i.next(), 5);
-    assert_eq!(i.next(), 6);
-    assert_eq!(i.next(), 7);
-    assert_eq!(i.next(), 8);
-    assert_eq!(i.next(), 9);
-    assert_eq!(i.next(), 10);
-    assert_eq!(i.next(), 11);
-}
 
 fn get_part_size(file: &File) -> Result<u64, anyhow::Error> {
     let sizes = [

--- a/src/multipart_upload.rs
+++ b/src/multipart_upload.rs
@@ -15,15 +15,15 @@ use std::os::unix::fs::MetadataExt;
 const ONE_MB: usize = 1048576;
 const MAX_PART_AMOUNT: u64 = 10000;
 
-struct InfiniteIndeces {
+pub struct InfiniteIndeces {
     value: usize,
 }
 
 impl InfiniteIndeces {
-    fn new() -> Self {
+    pub fn new() -> Self {
         InfiniteIndeces { value: 0 }
     }
-    fn next(&mut self) -> usize {
+    pub fn next(&mut self) -> usize {
         self.value = self.value + 1;
         self.value
     }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,6 +1,12 @@
 use anyhow::anyhow;
+use aws_sdk_glacier::operation::describe_job::builders::DescribeJobFluentBuilder;
+use aws_sdk_glacier::operation::describe_job::DescribeJobOutput;
 use aws_sdk_glacier::operation::initiate_job::InitiateJobOutput;
 use colored::Colorize;
+use std::fs::File;
+use std::time::Duration;
+
+use aws_sdk_glacier::operation::get_job_output::builders::GetJobOutputFluentBuilder;
 use crossterm::terminal::size;
 use crossterm::ExecutableCommand;
 use crossterm::{
@@ -10,12 +16,13 @@ use crossterm::{
 use home::home_dir;
 use ratatui::{prelude::*, widgets::*};
 use serde::{Deserialize, Serialize};
-use std::fs;
 use std::io::Read;
 use std::io::{stdout, Write};
 use std::time;
+use std::{fs, thread};
 
 pub const FOURTY_EIGHT_HOURS: i64 = 172800;
+const SLEEP_DURATION: u64 = 60 * 60;
 
 pub enum Status {
     Failed = 1,
@@ -139,6 +146,62 @@ pub async fn delete_expired_jobs_from_local() -> Result<(), anyhow::Error> {
     let buffer = serde_json::to_vec(&jobs)?;
     job_writer(buffer).await?;
     Ok(())
+}
+
+pub async fn get_job_output(
+    builder: GetJobOutputFluentBuilder,
+    mut file: File,
+) -> Result<Status, anyhow::Error> {
+    match builder.send().await {
+        Ok(output) => {
+            let desc = String::from(output.archive_description().unwrap_or_else(|| "inventory"));
+            let mut buffer = output.body;
+            println!("{}: {}", Colorize::green("downloading"), desc);
+            while let Some(bytes) = buffer.try_next().await? {
+                file.write(&bytes)?;
+            }
+            println!("{}: {}", Colorize::green("writing complete"), desc);
+            Ok(Status::Done)
+        }
+        Err(reason) => {
+            println!("failed to get inventory output: {}", reason);
+            Ok(Status::Failed)
+        }
+    }
+}
+pub async fn describe_job_loop(
+    builder: DescribeJobFluentBuilder,
+) -> Result<DescribeJobOutput, anyhow::Error> {
+    loop {
+        match describe_job_output(&builder).await {
+            Ok((Status::Done, output)) => {
+                break Ok(output.unwrap());
+            }
+            Ok((Status::Pending, _)) => {
+                println!("job is not ready - going to sleep and will try again in an hour",);
+                thread::sleep(Duration::from_secs(SLEEP_DURATION))
+            }
+            _ => {
+                println!("describe_job failed");
+                break Err(anyhow!("describe error failed!"));
+            }
+        }
+    }
+}
+
+pub async fn describe_job_output(
+    builder: &DescribeJobFluentBuilder,
+) -> Result<(Status, Option<DescribeJobOutput>), anyhow::Error> {
+    match builder.clone().send().await {
+        Ok(output) => {
+            if output.completed() {
+                Ok((Status::Done, Some(output)))
+            } else {
+                Ok((Status::Pending, None))
+            }
+        }
+        Err(err) => Err(anyhow!(err)),
+    }
 }
 
 pub async fn get_jobs() -> Result<Vec<InitiatedJob>, anyhow::Error> {

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -14,6 +14,8 @@ use std::io::Read;
 use std::io::{stdout, Write};
 use std::time;
 
+pub const FOURTY_EIGHT_HOURS: i64 = 172800;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub enum JobType {
     Inventory = 1,
@@ -115,7 +117,11 @@ pub fn basmati_directory() -> String {
 // this can be generic over any kinf of job in the future.
 pub async fn delete_invetory_job(vault: String) -> Result<(), anyhow::Error> {
     let jobs = get_jobs().await?;
-    let jobs: Vec<InitiatedJob> = jobs.into_iter().filter(|x| x.vault != vault).collect();
+    let jobs: Vec<InitiatedJob> = jobs
+        .into_iter()
+        .filter(|x| x.vault != vault)
+        .filter(|x| chrono::Utc::now().timestamp() - x.timestamp < FOURTY_EIGHT_HOURS)
+        .collect();
     let buffer = serde_json::to_vec(&jobs)?;
     job_writer(buffer).await?;
     Ok(())

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -333,75 +333,6 @@ pub fn confirm(title: String, confirmation_items: Vec<String>) -> Result<bool, a
     Ok(return_value.unwrap())
 }
 
-pub fn select_archive(mut events: Events<ArchiveItem>) -> Result<ArchiveItem, anyhow::Error> {
-    enable_raw_mode()?;
-    stdout().execute(EnterAlternateScreen)?;
-    let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
-    let mut should_quit = false;
-    let mut return_value = None;
-    while !should_quit {
-        terminal.draw(|frame| {
-            let area = frame.size();
-            let list_items: Vec<&str> = events
-                .items
-                .iter()
-                .map(|x| x.archive_description.as_str())
-                .collect();
-
-            let block = Block::default()
-                .title("Archives")
-                .green()
-                .borders(Borders::ALL);
-
-            let list = List::new(list_items)
-                .bold()
-                .green()
-                .block(block)
-                .highlight_style(Style::new().italic())
-                .highlight_symbol("->")
-                .repeat_highlight_symbol(true);
-
-            frame.render_stateful_widget(list, area, &mut events.state)
-        })?;
-        if event::poll(time::Duration::from_millis(50))? {
-            if let Event::Key(key) = event::read()? {
-                if key.kind == event::KeyEventKind::Press && key.code == KeyCode::Char('q') {
-                    should_quit = true;
-                }
-                if key.kind == event::KeyEventKind::Press && key.code == KeyCode::Char('j') {
-                    events.next();
-                }
-                if key.kind == event::KeyEventKind::Press && key.code == KeyCode::Char('k') {
-                    events.previous();
-                }
-                if key.kind == event::KeyEventKind::Press && key.code == KeyCode::Down {
-                    events.next();
-                }
-                if key.kind == event::KeyEventKind::Press && key.code == KeyCode::Up {
-                    events.previous();
-                }
-                if key.kind == event::KeyEventKind::Press && key.code == KeyCode::Esc {
-                    should_quit = true;
-                }
-                if key.kind == event::KeyEventKind::Press && key.code == KeyCode::Enter {
-                    match events.choose() {
-                        Some(value) => {
-                            should_quit = true;
-                            return_value = Some(value);
-                        }
-                        None => {
-                            should_quit = true;
-                            println!("could not match user input")
-                        }
-                    }
-                }
-            }
-        }
-    }
-    release_terminal().expect("Issue releasing the temrinal");
-    Ok(return_value.unwrap())
-}
-
 pub fn select_multiple_archives(
     mut events: Events<ArchiveItem>,
 ) -> Result<Vec<ArchiveItem>, anyhow::Error> {
@@ -438,7 +369,7 @@ pub fn select_multiple_archives(
                 .collect();
 
             let block = Block::default()
-                .title("Archives")
+                .title("Archives | <Space> to select <Enter> to confirm selection")
                 .green()
                 .borders(Borders::ALL);
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -150,7 +150,7 @@ pub async fn save_job_output(job_output: InitiatedJob) -> Result<(), anyhow::Err
 
 pub async fn create_if_not_exists(path: &str) {
     match fs::create_dir_all(&path) {
-        Ok(_) => println!("Created the following directory successfully - {}", &path),
+        Ok(_) => println!("using basmati directory at {}", &path),
         Err(_) => clean_splits(path).await,
     }
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -21,7 +21,7 @@ use std::io::{stdout, Write};
 use std::time;
 use std::{fs, thread};
 
-pub const FOURTY_EIGHT_HOURS: i64 = 172800;
+pub const TWENTY_FOUR_HOURS: i64 = 86400;
 const SLEEP_DURATION: u64 = 60 * 60;
 
 pub enum Status {
@@ -141,7 +141,7 @@ pub async fn delete_expired_jobs_from_local() -> Result<(), anyhow::Error> {
     let jobs = get_jobs().await?;
     let jobs: Vec<InitiatedJob> = jobs
         .into_iter()
-        .filter(|x| chrono::Utc::now().timestamp() - x.timestamp < FOURTY_EIGHT_HOURS)
+        .filter(|x| chrono::Utc::now().timestamp() - x.timestamp < TWENTY_FOUR_HOURS)
         .collect();
     let buffer = serde_json::to_vec(&jobs)?;
     job_writer(buffer).await?;

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -169,6 +169,7 @@ pub async fn get_job_output(
         }
     }
 }
+
 pub async fn describe_job_loop(
     builder: DescribeJobFluentBuilder,
 ) -> Result<DescribeJobOutput, anyhow::Error> {
@@ -178,12 +179,15 @@ pub async fn describe_job_loop(
                 break Ok(output.unwrap());
             }
             Ok((Status::Pending, _)) => {
-                println!("job is not ready - going to sleep and will try again in an hour",);
+                println!(
+                    "job is not ready - going to sleep and will try again in {} ms",
+                    SLEEP_DURATION
+                );
                 thread::sleep(Duration::from_secs(SLEEP_DURATION))
             }
             _ => {
                 println!("describe_job failed");
-                break Err(anyhow!("describe error failed!"));
+                break Err(anyhow!("describe job failed!"));
             }
         }
     }
@@ -512,4 +516,33 @@ fn release_terminal() -> Result<(), anyhow::Error> {
         .execute(LeaveAlternateScreen)
         .expect("failed releasing terminal");
     Ok(())
+}
+
+pub struct InfiniteIndeces {
+    value: usize,
+}
+
+impl InfiniteIndeces {
+    pub fn new() -> Self {
+        InfiniteIndeces { value: 0 }
+    }
+    pub fn next(&mut self) -> usize {
+        self.value = self.value + 1;
+        self.value
+    }
+}
+#[test]
+fn test_infinite_indeces() {
+    let mut i = InfiniteIndeces::new();
+    assert_eq!(i.next(), 1);
+    assert_eq!(i.next(), 2);
+    assert_eq!(i.next(), 3);
+    assert_eq!(i.next(), 4);
+    assert_eq!(i.next(), 5);
+    assert_eq!(i.next(), 6);
+    assert_eq!(i.next(), 7);
+    assert_eq!(i.next(), 8);
+    assert_eq!(i.next(), 9);
+    assert_eq!(i.next(), 10);
+    assert_eq!(i.next(), 11);
 }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -180,8 +180,8 @@ pub async fn describe_job_loop(
             }
             Ok((Status::Pending, _)) => {
                 println!(
-                    "job is not ready - going to sleep and will try again in {} ms",
-                    SLEEP_DURATION
+                    "job is not ready - going to sleep and will try again in {} minutes",
+                    SLEEP_DURATION / 60
                 );
                 thread::sleep(Duration::from_secs(SLEEP_DURATION))
             }


### PR DESCRIPTION
-  Add ability to finish jobs at a later time. We now keep the outputs of the `initiated` jobs on the file system so that we can run checks when starting the app and see if there is anything needing pick up
- Factor out common functionality for downloading archives and inventory into some common function in shared.rs